### PR TITLE
Fix using input instead of select elements with input-append

### DIFF
--- a/select2-bootstrap.css
+++ b/select2-bootstrap.css
@@ -75,6 +75,11 @@
   display:none;
 }
 
+.input-append .select2-offscreen,
+.input-prepend .select2-offscreen {
+  position: absolute;
+}
+
 /**
  * This stops the quick flash when a native selectbox is shown and 
  * then replaced by a select2 input when javascript kicks in. This can be 


### PR DESCRIPTION
Thank you very much for the very nice styles! When I am using an `input`instead of a `select` element (e.g. because of select2's ajax feature doesn't work with `input` elements), then the resulting dropdown have some ugly space:

![input_append](https://f.cloud.github.com/assets/17513/334551/06b47308-9c76-11e2-8c38-31d14979b4c9.png)

Using the appended styles fixes the problem:

![input_append_fixed](https://f.cloud.github.com/assets/17513/334556/1706c0e4-9c76-11e2-914a-bf2a74231599.png)

Explanation of fix:  Bootstrap sets `.input-append input{position:relative}` which overrides `.select2-offscreen{position: absolute}` .
