### PR TITLE
Added Bootstrap default width, input-* and span* class support

### DIFF
--- a/lib/select2-bootstrap.less
+++ b/lib/select2-bootstrap.less
@@ -6,17 +6,17 @@
  
 .select2-container {
   vertical-align: middle;
-   width: 220px;
-   &.input-mini       { width: 60px; }
-   &.input-small      { width: 90px; }
-   &.input-medium     { width: 150px; }
-   &.input-large      { width: 210px; }
-   &.input-xlarge     { width: 270px; }
-   &.input-xxlarge    { width: 530px; }
-   &[class*="span"] {
-     float: none;
-     margin-left: 0;
-   }
+  width: 220px;
+  &.input-mini       { width: 60px; }
+  &.input-small      { width: 90px; }
+  &.input-medium     { width: 150px; }
+  &.input-large      { width: 210px; }
+  &.input-xlarge     { width: 270px; }
+  &.input-xxlarge    { width: 530px; }
+  &[class*="span"] {
+    float: none;
+    margin-left: 0;
+  }
 }
 
 .select2-container .select2-choice,

--- a/lib/select2-bootstrap.scss
+++ b/lib/select2-bootstrap.scss
@@ -6,17 +6,17 @@
  
 .select2-container {
   vertical-align: middle;
-   width: 220px;
-   &.input-mini       { width: 60px; }
-   &.input-small      { width: 90px; }
-   &.input-medium     { width: 150px; }
-   &.input-large      { width: 210px; }
-   &.input-xlarge     { width: 270px; }
-   &.input-xxlarge    { width: 530px; }
-   &[class*="span"] {
-     float: none;
-     margin-left: 0;
-   }
+  width: 220px;
+  &.input-mini       { width: 60px; }
+  &.input-small      { width: 90px; }
+  &.input-medium     { width: 150px; }
+  &.input-large      { width: 210px; }
+  &.input-xlarge     { width: 270px; }
+  &.input-xxlarge    { width: 530px; }
+  [class*="span"] {
+    float: none;
+    margin-left: 0;
+  }
 }
 
 .select2-container .select2-choice,


### PR DESCRIPTION
I found these changes necessary so that select2 sizes and aligns correctly when using bootstrap `input-*` and `span*` classes.  I found with these changes, along with setting the select2 option `width: off` worked very well.
