### PR TITLE
Input outline fixes

### DIFF
--- a/lib/select2-bootstrap.less
+++ b/lib/select2-bootstrap.less
@@ -54,6 +54,7 @@
 .select2-container-active .select2-choice,
 .select2-container-multi.select2-container-active .select2-choices {
   border-color: rgba(82, 168, 236, 0.8);
+  border-color: #ccc\0;
   outline: none;
   .box-shadow(~"inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6)");
 }

--- a/lib/select2-bootstrap.scss
+++ b/lib/select2-bootstrap.scss
@@ -54,6 +54,7 @@
 .select2-container-active .select2-choice,
 .select2-container-multi.select2-container-active .select2-choices {
   border-color: rgba(82, 168, 236, 0.8);
+  border-color: #ccc\0;
   outline: none;
   @include box-shadow(inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6));
 }

--- a/select2-bootstrap.css
+++ b/select2-bootstrap.css
@@ -69,6 +69,7 @@
 .select2-container-active .select2-choice,
 .select2-container-multi.select2-container-active .select2-choices {
   border-color: rgba(82, 168, 236, 0.8);
+  border-color: #ccc\0;
   outline: none;
   -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
   -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);


### PR DESCRIPTION
Fixed input outline colour.

<sup> On a side note, you should probably include `compass` in your gemspec since it's required. Or better yet, remove the compass dependency altogether and use asset pipeline. :) </sup>
