### PR TITLE
Improve Bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,6 +9,9 @@
     "node_modules",
     "components"
   ],
+  "dependencies": {
+    "select2": "^3.3.2"
+  },
   "devDependencies": {
     "bootstrap": "~2.3.1",
     "sass-bootstrap": "git://github.com/jlong/sass-twitter-bootstrap.git#~2.3.1"


### PR DESCRIPTION
Hi, I've noticed that `main` and `dependencies` are missing from `bower.json`. This is important to define them as external tools/plugins (like [grunt-bower](https://www.npmjs.org/package/grunt-bower) and [gulp-bower-files](https://www.npmjs.org/package/gulp-bower-files)) may use them.
