### PR TITLE
bootstrap3 v1.4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ in latest Chrome, Safari, Firefox, Opera (Mac) and IE8-IE10.
 
 ##### Changelog
 
+###### v1.4.4
+
+ * Don't hardcode :focus box-shadow colour ([#58](https://github.com/t0m/select2-bootstrap-css/issues/58)).
+
 ###### v1.4.3
 
  * Removed gradient for `.select2-dropdown-open.select2-drop-above [class^="select2-choice"]` in IE <= 9; really fixes [#35](https://github.com/t0m/select2-bootstrap-css/issues/35).

--- a/_jekyll/css/select2-bootstrap.css
+++ b/_jekyll/css/select2-bootstrap.css
@@ -1,5 +1,5 @@
 /**
- * Select2 Bootstrap 3 CSS v1.4.3
+ * Select2 Bootstrap 3 CSS v1.4.4
  * Tested with Bootstrap v3.3.1 and Select2 v3.3.2, v3.4.1-v3.4.5, v3.5.1, v3.5.2, master
  * in latest Chrome, Safari, Firefox, Opera (Mac) and IE8-IE11
  * MIT License
@@ -280,8 +280,8 @@
 .select2-container-multi.select2-container-active .select2-choices {
   border-color: #66afe9;
   outline: none;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
   -webkit-transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
   -o-transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
   transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "select2-bootstrap-css",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "main": [
     "select2-bootstrap.css"
   ],

--- a/docs/css/select2-bootstrap.css
+++ b/docs/css/select2-bootstrap.css
@@ -1,5 +1,5 @@
 /**
- * Select2 Bootstrap 3 CSS v1.4.3
+ * Select2 Bootstrap 3 CSS v1.4.4
  * Tested with Bootstrap v3.3.1 and Select2 v3.3.2, v3.4.1-v3.4.5, v3.5.1, v3.5.2, master
  * in latest Chrome, Safari, Firefox, Opera (Mac) and IE8-IE11
  * MIT License
@@ -280,8 +280,8 @@
 .select2-container-multi.select2-container-active .select2-choices {
   border-color: #66afe9;
   outline: none;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
   -webkit-transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
   -o-transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
   transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;

--- a/lib/select2-bootstrap.less
+++ b/lib/select2-bootstrap.less
@@ -1,5 +1,5 @@
 /**
- * Select2 Bootstrap 3 CSS v1.4.3
+ * Select2 Bootstrap 3 CSS v1.4.4
  * Tested with Bootstrap v3.3.1 and Select2 v3.3.2, v3.4.1-v3.4.5, v3.5.1, v3.5.2, master
  * in latest Chrome, Safari, Firefox, Opera (Mac) and IE8-IE11
  * MIT License
@@ -266,7 +266,7 @@
 .select2-container-multi.select2-container-active .select2-choices {
   border-color: @input-border-focus;
   outline: none;
-  @shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
+  @shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px fade(@input-border-focus, 60%);
   .box-shadow(@shadow);
   @transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
   .transition(@transition);

--- a/lib/select2-bootstrap.scss
+++ b/lib/select2-bootstrap.scss
@@ -1,5 +1,5 @@
 /**
- * Select2 Bootstrap 3 CSS v1.4.3
+ * Select2 Bootstrap 3 CSS v1.4.4
  * Tested with Bootstrap v3.3.1 and Select2 v3.3.2, v3.4.1-v3.4.5, v3.5.1, v3.5.2, master
  * in latest Chrome, Safari, Firefox, Opera (Mac) and IE8-IE11
  * MIT License
@@ -266,7 +266,7 @@
 .select2-container-multi.select2-container-active .select2-choices {
   border-color: $input-border-focus;
   outline: none;
-  $shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
+  $shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba($input-border-focus, 0.6);
   @include box-shadow($shadow);
   $transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
   @include transition($transition);

--- a/lib/select2-bootstrap/version.rb
+++ b/lib/select2-bootstrap/version.rb
@@ -2,7 +2,7 @@ module Select2
   module Bootstrap
     # This is updated via the `grunt bump` command, which has a pretty 
     # unflexible matching syntax.
-    VERSION_STRING = "'version': '1.4.3'"
+    VERSION_STRING = "'version': '1.4.4'"
     # Then, just the version.
     VERSION = VERSION_STRING.match(/\d+\.\d+\.\d+/)[0]
   end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "select2-bootstrap-css",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "simple css to make select2 widgets fit in with bootstrap",
   "main": "",
   "directories": {

--- a/select2-bootstrap.css
+++ b/select2-bootstrap.css
@@ -1,5 +1,5 @@
 /**
- * Select2 Bootstrap 3 CSS v1.4.3
+ * Select2 Bootstrap 3 CSS v1.4.4
  * Tested with Bootstrap v3.3.1 and Select2 v3.3.2, v3.4.1-v3.4.5, v3.5.1, v3.5.2, master
  * in latest Chrome, Safari, Firefox, Opera (Mac) and IE8-IE11
  * MIT License
@@ -280,8 +280,8 @@
 .select2-container-multi.select2-container-active .select2-choices {
   border-color: #66afe9;
   outline: none;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(82, 168, 236, 0.6);
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
   -webkit-transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
   -o-transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
   transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;


### PR DESCRIPTION
- Don't hardcode :focus box-shadow colour ([#58](https://github.com/t0m/select2-bootstrap-css/issues/58)).
