### PR TITLE
Add ignore folder to bower.json file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,8 +6,9 @@
   ],
   "ignore": [
     "**/.*",
-    "node_modules",
-    "components"
+    "_jekyll",
+    "docs",
+    "test"
   ],
   "dependencies": {
     "select2": "^3.3.2"


### PR DESCRIPTION
The folders `_jekyll`, `docs`, `test`, not need be included on download of package with bower.
